### PR TITLE
Composer requirements improve

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
     }
     , "require": {
         "cakephp/cakephp": "~3.0"
-        , "respect/validation": "0.8.*"
-        , "ronanguilloux/isocodes": "dev-master"
+        , "respect/validation": "~0.8"
+        , "ronanguilloux/isocodes": "~1.1"
     }
     , "require-dev": {
-        "phpunit/phpunit": "4.1.*"
+        "phpunit/phpunit": "~4.1"
     }
     , "autoload": {
         "psr-4": {


### PR DESCRIPTION
In a nutshell:
- `"respect/validation": "~0.8"` => To get latest minor version of it
- `"ronanguilloux/isocodes": "~1.1"` => This library has stable releases now.
- `"phpunit/phpunit": "~4.1"` => To get latest minor version of it

Some of your dependencies are out of date. This PR should fix it.

See: https://www.versioneye.com/php/gourmet:validation

Regards
